### PR TITLE
Potential fix for code scanning alert no. 18: Multiplication result converted to larger type

### DIFF
--- a/native/addons/ScreenCapturer/capture.cpp
+++ b/native/addons/ScreenCapturer/capture.cpp
@@ -27,7 +27,7 @@ class CaptureWorker : public Napi::AsyncWorker {
         }
 
         // Allocate buffer for capture data
-        size_t bufferSize = width_ * height_ * 4;
+        size_t bufferSize = static_cast<size_t>(width_) * static_cast<size_t>(height_) * static_cast<size_t>(4);
         buffer_.resize(bufferSize);
 
         // Capture window


### PR DESCRIPTION
Potential fix for [https://github.com/nzh63/Ame/security/code-scanning/18](https://github.com/nzh63/Ame/security/code-scanning/18)

To fix this safely, force the multiplication to happen in an unsigned wide type (`size_t`) from the first operand, not after the full expression is evaluated.

Best minimal fix (without changing functionality): update line 30 in `native/addons/ScreenCapturer/capture.cpp` so at least one multiplicand is cast to `size_t` before multiplication, e.g.:
- `static_cast<size_t>(width_) * static_cast<size_t>(height_) * static_cast<size_t>(4)`

This preserves behavior for valid values, eliminates `int` intermediate overflow, and satisfies the CodeQL rule. No new methods/imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
